### PR TITLE
Add option to automically add webp image formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The [web intl extension](docs/intl.md) gives you a simple and efficient way to g
 
 [More](docs/intl.md)
 
-### 4. count
+### 4. Count
 
 The [web count extension](docs/count.md) gives you a simple and efficient way to have a global counter in your twig template.
 

--- a/docs/image.md
+++ b/docs/image.md
@@ -183,3 +183,47 @@ services:
             $defaultAttributes:
                 loading: 'lazy'
 ```
+
+##### 7. Webp Support
+
+If your server supports converting image to webp you can automatically enable the webp output for all images
+the following way:
+
+```yaml
+services:
+    Sulu\Twig\Extensions\ImageExtension:
+        arguments:
+            $additionalTypes:
+                webp: 'image/webp'
+```
+
+This will render a picture tag which look like the following:
+
+```twig
+<picture>
+    <source media="(max-width: 1024px)"
+            srcset="/uploads/media/sulu-170x170/01/image.webp?v=1-0"
+            type="image/webp">
+    <source media="(max-width: 1024px)"
+            srcset="/uploads/media/sulu-170x170/01/image.jpg?v=1-0">
+    <source media="(max-width: 650px)"
+            srcset="/uploads/media/sulu-100x100/01/image.webp?v=1-0"
+            type="image/webp">
+    <source media="(max-width: 650px)"
+            srcset="/uploads/media/sulu-100x100/01/image.jpg?v=1-0">
+    <source srcset="/uploads/media/sulu-100x100/01/image.webp?v=1-0"
+            type="image/webp">
+    <img alt="Title"
+         title="Description"
+         src="/uploads/media/sulu-400x400/01/image.jpg?v=1-0">
+</picture>
+```
+
+You can also only activate it for a specific call:
+
+```twig
+{{ get_image(headerImage, 'sulu-400x400', {
+    '(max-width: 1024px)': 'sulu-170x170',
+    '(max-width: 650px)': 'sulu-100x100',
+}, { webp: 'image/webp' }) }}
+```

--- a/docs/image.md
+++ b/docs/image.md
@@ -186,14 +186,14 @@ services:
 
 ##### 7. Webp Support
 
-If your server supports converting image to webp you can automatically enable the webp output for all images
-the following way:
+If your server supports converting images to webp you can automatically enable webp
+output for the image twig functions per default the following way:
 
 ```yaml
 services:
     Sulu\Twig\Extensions\ImageExtension:
         arguments:
-            $additionalTypes:
+            $defaultAdditionalTypes:
                 webp: 'image/webp'
 ```
 

--- a/src/ImageExtension.php
+++ b/src/ImageExtension.php
@@ -67,19 +67,19 @@ class ImageExtension extends AbstractExtension
 
     /**
      * @param string[] $defaultAttributes
-     * @param string[] $additionalTypes
+     * @param string[] $defaultAdditionalTypes
      */
     public function __construct(
         ?string $placeholderPath = null,
         array $defaultAttributes = [],
-        array $additionalTypes = []
+        array $defaultAdditionalTypes = []
     ) {
         if (null !== $placeholderPath) {
             $this->placeholderPath = rtrim($placeholderPath, '/') . '/';
         }
 
         $this->defaultAttributes = $defaultAttributes;
-        $this->defaultAdditionalTypes = $additionalTypes;
+        $this->defaultAdditionalTypes = $defaultAdditionalTypes;
     }
 
     /**

--- a/tests/ImageExtensionTest.php
+++ b/tests/ImageExtensionTest.php
@@ -28,12 +28,18 @@ class ImageExtensionTest extends TestCase
      */
     private $image;
 
+    /**
+     * @var mixed[]
+     */
+    private $svgImage;
+
     public function setUp(): void
     {
         $this->imageExtension = new ImageExtension('/lazy');
         $this->image = [
             'title' => 'Title',
             'description' => 'Description',
+            'mimeType' => 'image/jpeg',
             'thumbnails' => [
                 'sulu-100x100' => '/uploads/media/sulu-100x100/01/image.jpg?v=1-0',
                 'sulu-100x100.webp' => '/uploads/media/sulu-100x100/01/image.webp?v=1-0',
@@ -42,6 +48,22 @@ class ImageExtensionTest extends TestCase
                 'sulu-170x170' => '/uploads/media/sulu-170x170/01/image.jpg?v=1-0',
                 'sulu-170x170.webp' => '/uploads/media/sulu-170x170/01/image.webp?v=1-0',
                 'sulu-400x400' => '/uploads/media/sulu-400x400/01/image.jpg?v=1-0',
+                'sulu-400x400.webp' => '/uploads/media/sulu-400x400/01/image.webp?v=1-0',
+            ],
+        ];
+
+        $this->svgImage = [
+            'title' => 'Title',
+            'description' => 'Description',
+            'mimeType' => 'image/svg',
+            'thumbnails' => [
+                'sulu-100x100' => '/uploads/media/sulu-100x100/01/image.svg?v=1-0',
+                'sulu-100x100.webp' => '/uploads/media/sulu-100x100/01/image.webp?v=1-0',
+                'sulu-100x100@2x' => '/uploads/media/sulu-100x100@2x/01/image.svg?v=1-0',
+                'sulu-100x100@2x.webp' => '/uploads/media/sulu-100x100@2x/01/image.webp?v=1-0',
+                'sulu-170x170' => '/uploads/media/sulu-170x170/01/image.svg?v=1-0',
+                'sulu-170x170.webp' => '/uploads/media/sulu-170x170/01/image.webp?v=1-0',
+                'sulu-400x400' => '/uploads/media/sulu-400x400/01/image.svg?v=1-0',
                 'sulu-400x400.webp' => '/uploads/media/sulu-400x400/01/image.webp?v=1-0',
             ],
         ];
@@ -292,6 +314,20 @@ class ImageExtensionTest extends TestCase
                 ' src="/uploads/media/sulu-100x100/01/image.jpg?v=1-0">' .
             '</picture>',
             $imageExtension->getImage($this->image, [
+                'src' => 'sulu-100x100',
+            ])
+        );
+    }
+
+    public function testIgnoreAdditionalTypesForSvg(): void
+    {
+        $imageExtension = new ImageExtension(null, [], ['webp' => 'image/webp']);
+
+        $this->assertSame(
+        '<img alt="Title"' .
+            ' title="Description"' .
+            ' src="/uploads/media/sulu-100x100/01/image.svg?v=1-0">',
+            $imageExtension->getImage($this->svgImage, [
                 'src' => 'sulu-100x100',
             ])
         );

--- a/tests/ImageExtensionTest.php
+++ b/tests/ImageExtensionTest.php
@@ -36,8 +36,13 @@ class ImageExtensionTest extends TestCase
             'description' => 'Description',
             'thumbnails' => [
                 'sulu-100x100' => '/uploads/media/sulu-100x100/01/image.jpg?v=1-0',
+                'sulu-100x100.webp' => '/uploads/media/sulu-100x100/01/image.webp?v=1-0',
+                'sulu-100x100@2x' => '/uploads/media/sulu-100x100@2x/01/image.jpg?v=1-0',
+                'sulu-100x100@2x.webp' => '/uploads/media/sulu-100x100@2x/01/image.webp?v=1-0',
                 'sulu-170x170' => '/uploads/media/sulu-170x170/01/image.jpg?v=1-0',
+                'sulu-170x170.webp' => '/uploads/media/sulu-170x170/01/image.webp?v=1-0',
                 'sulu-400x400' => '/uploads/media/sulu-400x400/01/image.jpg?v=1-0',
+                'sulu-400x400.webp' => '/uploads/media/sulu-400x400/01/image.webp?v=1-0',
             ],
         ];
     }
@@ -271,6 +276,115 @@ class ImageExtensionTest extends TestCase
                 'src' => 'sulu-100x100',
                 'loading' => null,
             ])
+        );
+    }
+
+    public function testDefaultAdditionalTypes(): void
+    {
+        $imageExtension = new ImageExtension(null, [], ['webp' => 'image/webp']);
+
+        $this->assertSame(
+            '<picture>' .
+            '<source srcset="/uploads/media/sulu-100x100/01/image.webp?v=1-0"' .
+                ' type="image/webp">' .
+            '<img alt="Title"' .
+                ' title="Description"' .
+                ' src="/uploads/media/sulu-100x100/01/image.jpg?v=1-0">' .
+            '</picture>',
+            $imageExtension->getImage($this->image, [
+                'src' => 'sulu-100x100',
+            ])
+        );
+    }
+
+    public function testAdditionalTypes(): void
+    {
+        $imageExtension = new ImageExtension(null, [], []);
+
+        $this->assertSame(
+            '<picture>' .
+            '<source srcset="/uploads/media/sulu-100x100/01/image.webp?v=1-0"' .
+                ' type="image/webp">' .
+            '<img alt="Title"' .
+                ' title="Description"' .
+                ' src="/uploads/media/sulu-100x100/01/image.jpg?v=1-0">' .
+            '</picture>',
+            $imageExtension->getImage($this->image, [
+                'src' => 'sulu-100x100',
+            ], [], ['webp' => 'image/webp'])
+        );
+    }
+
+    public function testAdditionalTypesWithSrcSet(): void
+    {
+        $imageExtension = new ImageExtension(null, [], []);
+
+        $this->assertSame(
+            '<picture>' .
+            '<source srcset="/uploads/media/sulu-100x100/01/image.webp?v=1-0, /uploads/media/sulu-100x100@2x/01/image.webp?v=1-0 2x"' .
+            ' type="image/webp">' .
+            '<img alt="Title"' .
+            ' title="Description"' .
+            ' src="/uploads/media/sulu-100x100/01/image.jpg?v=1-0"' .
+            ' srcset="/uploads/media/sulu-100x100@2x/01/image.jpg?v=1-0 2x">' .
+            '</picture>',
+            $imageExtension->getImage($this->image, [
+                'src' => 'sulu-100x100',
+                'srcset' => 'sulu-100x100@2x 2x',
+            ], [], ['webp' => 'image/webp'])
+        );
+    }
+
+    public function testAdditionalLazyComplexPictureTag(): void
+    {
+        $imageExtension = new ImageExtension('/lazy', [], ['webp' => 'image/webp']);
+
+        $this->assertSame(
+            '<picture>' .
+            '<source media="(max-width: 1024px)"' .
+                ' srcset="/lazy/sulu-400x400.svg 1024w, /lazy/sulu-170x170.svg 800w, /lazy/sulu-100x100.svg 460w"' .
+                ' data-srcset="/uploads/media/sulu-400x400/01/image.webp?v=1-0 1024w, /uploads/media/sulu-170x170/01/image.webp?v=1-0 800w, /uploads/media/sulu-100x100/01/image.webp?v=1-0 460w"' .
+                ' sizes="(max-width: 1024px) 100vw, (max-width: 800px) 100vw, 100vw"' .
+                ' type="image/webp">' .
+            '<source media="(max-width: 1024px)"' .
+                ' srcset="/lazy/sulu-400x400.svg 1024w, /lazy/sulu-170x170.svg 800w, /lazy/sulu-100x100.svg 460w"' .
+                ' data-srcset="/uploads/media/sulu-400x400/01/image.jpg?v=1-0 1024w, /uploads/media/sulu-170x170/01/image.jpg?v=1-0 800w, /uploads/media/sulu-100x100/01/image.jpg?v=1-0 460w"' .
+                ' sizes="(max-width: 1024px) 100vw, (max-width: 800px) 100vw, 100vw">' .
+            '<source media="(max-width: 650px)"' .
+                ' srcset="/lazy/sulu-400x400.svg 1024w, /lazy/sulu-170x170.svg 800w, /lazy/sulu-100x100.svg 460w"' .
+                ' data-srcset="/uploads/media/sulu-400x400/01/image.webp?v=1-0 1024w, /uploads/media/sulu-170x170/01/image.webp?v=1-0 800w, /uploads/media/sulu-100x100/01/image.webp?v=1-0 460w"' .
+                ' sizes="(max-width: 1024px) 100vw, (max-width: 800px) 100vw, 100vw"' .
+                ' type="image/webp">' .
+            '<source media="(max-width: 650px)"' .
+                ' srcset="/lazy/sulu-400x400.svg 1024w, /lazy/sulu-170x170.svg 800w, /lazy/sulu-100x100.svg 460w"' .
+                ' data-srcset="/uploads/media/sulu-400x400/01/image.jpg?v=1-0 1024w, /uploads/media/sulu-170x170/01/image.jpg?v=1-0 800w, /uploads/media/sulu-100x100/01/image.jpg?v=1-0 460w"' .
+                ' sizes="(max-width: 1024px) 100vw, (max-width: 800px) 100vw, 100vw">' .
+            '<source srcset="/lazy/sulu-400x400.svg"' .
+                ' data-srcset="/uploads/media/sulu-400x400/01/image.webp?v=1-0"' .
+                ' type="image/webp">' .
+            '<img alt="Title"' .
+                ' title="Description"' .
+                ' src="/lazy/sulu-400x400.svg"' .
+                ' data-src="/uploads/media/sulu-400x400/01/image.jpg?v=1-0"' .
+                ' class="image-class lazyload">' .
+            '</picture>',
+            $imageExtension->getLazyImage(
+                $this->image,
+                [
+                    'src' => 'sulu-400x400',
+                    'class' => 'image-class',
+                ],
+                [
+                    '(max-width: 1024px)' => [
+                        'srcset' => 'sulu-400x400 1024w, sulu-170x170 800w, sulu-100x100 460w',
+                        'sizes' => '(max-width: 1024px) 100vw, (max-width: 800px) 100vw, 100vw',
+                    ],
+                    '(max-width: 650px)' => [
+                        'srcset' => 'sulu-400x400 1024w, sulu-170x170 800w, sulu-100x100 460w',
+                        'sizes' => '(max-width: 1024px) 100vw, (max-width: 800px) 100vw, 100vw',
+                    ],
+                ]
+            )
         );
     }
 }


### PR DESCRIPTION
Use the following way to output all images also as webp:

```yaml
services:
    Sulu\Twig\Extensions\ImageExtension:
        arguments:
            $additionalTypes:
                webp: 'image/webp'
```