### PR TITLE
Add icon twig extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ The [web url extension](docs/url.md) gives you a simple and efficient way to get
 The [web editor extension](docs/editor.md) gives you a simple way to add classes on html provided by a text editor.
 
 [More](docs/editor.md)
+
+### 7. Icon
+
+The [icon extension](docs/icon.md) gives you a simple way to render icomoon icons.

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.11",
-        "jangregor/phpstan-prophecy": "^0.6",
+        "jangregor/phpstan-prophecy": "^0.8",
         "phpstan/phpstan": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12",
         "phpunit/phpunit": "^5.0 || ^6.0 || ^7.0 || ^7.1",

--- a/docs/icon.md
+++ b/docs/icon.md
@@ -1,0 +1,121 @@
+# Icon Extension
+
+The icon extension gives you a simple way to render icomoon icons.
+
+## Setup
+
+The twig extension need to be registered as [symfony service](http://symfony.com/doc/current/service_container.html).
+
+```yaml
+services:
+    Sulu\Twig\Extensions\IconExtension:
+        arguments:
+            $iconSets:
+                default:
+                    type: 'font' # or 'svg'
+                    # for svg also a path to symbol-defs file is needed:
+                    # path: '/website/fonts/icomoon-sulu/symbol-defs.svg'
+
+                    # the following options are optional but need to match your icomoon export settings:
+                    # className: 'icon' 
+                    # classPrefix: 'icon-' 
+                    # classSuffix: ''
+```
+
+## Usage
+
+### Icon Font
+
+```yaml
+services:
+    Sulu\Twig\Extensions\IconExtension:
+        arguments:
+            $iconSets:
+                default:
+                    type: 'font'
+```
+
+Now you can use the twig extension the following way:
+
+```twig
+{{ get_icon('test') }}
+```
+
+This will output:
+
+```html
+<span class="icon icon-test"></span>
+```
+
+### SVG Icon
+
+Icomoon also support svg icon. This twig extension target to make the switch easy
+by just changing the configuration:
+
+```yaml
+services:
+    Sulu\Twig\Extensions\IconExtension:
+        arguments:
+            $iconSets:
+                default:
+                    type: 'svg'
+                    path: '/path/to/symbol-defs.svg'
+```
+
+Call the twig extension again the following way:
+
+```twig
+{{ get_icon('test') }}
+```
+
+Will now output the icon the following way:
+
+```html
+<svg class="icon icon-test"><use xlink:href="/path/to/symbol-defs.svg#test"></use></svg>
+```
+
+### Additional class and Icon Sets
+
+```yaml
+services:
+    Sulu\Twig\Extensions\IconExtension:
+        arguments:
+            $iconSets:
+                default:
+                    type: 'font'
+                    className: 'my-icon'
+                    classPrefix: 'my-icon-'
+                    classSuffix: '-new'
+                other:
+                    type: 'svg'
+                    path: '/path/to/symbol-defs.svg'
+                    className: 'my-icon'
+                    classPrefix: 'my-icon-'
+                    classSuffix: '-new'
+```
+
+If you use icomoon as icon font you can use the twig extension the following way:
+
+```twig
+<!-- Icon Font -->
+{{ get_icon('test', 'other-class') }}
+
+<!-- SVG Icons -->
+{{ get_icon('test', 'other-class', 'other') }}
+```
+
+This will output:
+
+```html
+<!-- Icon Font -->
+<span class="other-class my-icon my-icon-test-new"></span>
+
+<!-- SVG Icons -->
+<svg class="other-class my-icon my-icon-test-new"><use xlink:href="/path/to/symbol-defs.svg#test"></use></svg>
+```
+
+As you see above the format for the classes is the following:
+
+```
+{additionaClass} {className} {classPrefix}{icon}{classSuffix}
+```

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - vendor/jangregor/phpstan-prophecy/src/extension.neon
+    - vendor/jangregor/phpstan-prophecy/extension.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-phpunit/rules.neon
     - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon

--- a/src/IconExtension.php
+++ b/src/IconExtension.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Twig\Extensions;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * This Twig Extension manage icomoon icons and allow easy switch between svg and font icons.
+ */
+class IconExtension extends AbstractExtension
+{
+    const ICON_SET_TYPE_SVG = 'svg';
+    const ICON_SET_TYPE_FONT = 'font';
+
+    /**
+     * @var mixed[]
+     */
+    private $iconSets = [];
+
+    /**
+     * @param string|mixed[] $iconSets
+     */
+    public function __construct($iconSets)
+    {
+        if (\is_string($iconSets)) {
+            $iconSets = [
+                'default' => $iconSets,
+            ];
+        }
+
+        foreach ($iconSets as $iconSetName => $iconSet) {
+            if (\is_string($iconSet)) {
+                if (self::ICON_SET_TYPE_FONT === $iconSet) {
+                    $iconSet = [
+                        'type' => self::ICON_SET_TYPE_FONT,
+                    ];
+                } else {
+                    $iconSet = [
+                        'type' => self::ICON_SET_TYPE_SVG,
+                        'path' => $iconSet,
+                    ];
+                }
+            }
+
+            if (self::ICON_SET_TYPE_SVG === $iconSet['type'] && !isset($iconSet['path'])) {
+                throw new \LogicException('Expected "path" to be set for "svg" icon.');
+            }
+
+            $iconSet['className'] = $iconSet['className'] ?? 'icon';
+            $iconSet['classPrefix'] = $iconSet['classPrefix'] ?? 'icon-';
+            $iconSet['classSuffix'] = $iconSet['classSuffix'] ?? '';
+
+            $this->iconSets[$iconSetName] = $iconSet;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return [
+            new TwigFunction('get_icon', [$this, 'getIcon'], ['pre_escape' => 'html', 'is_safe' => ['html']]),
+        ];
+    }
+
+    /**
+     * Get the an icomoon icon based on the configuration.
+     *
+     * @param string $icon
+     * @param string $className
+     * @param string $iconSetName
+     *
+     * @return string
+     */
+    public function getIcon(string $icon, ?string $className = '', string $iconSetName = 'default'): string
+    {
+        $iconSet = $this->getIconSet($iconSetName);
+
+        $className = trim(sprintf(
+            '%s %s %s%s%s',
+            $className ?: '',
+            $iconSet['className'],
+            $iconSet['classPrefix'],
+            $icon,
+            $iconSet['classSuffix']
+        ));
+
+        if (self::ICON_SET_TYPE_FONT === $iconSet['type']) {
+            return sprintf('<span class="%s"></span>', $className);
+        }
+
+        return sprintf(
+            '<svg class="%s"><use xlink:href="%s#%s"></use></svg>',
+            $className,
+            $iconSet['path'],
+            $icon
+        );
+    }
+
+    /**
+     * @return mixed[]
+     */
+    private function getIconSet(string $name): array
+    {
+        if (!isset($this->iconSets[$name])) {
+            throw new \InvalidArgumentException(sprintf(
+                'Icon Set with name "%s" not found, found: "%s".',
+                $name,
+                implode('", "', array_keys($this->iconSets))
+            ));
+        }
+
+        return $this->iconSets[$name];
+    }
+}

--- a/tests/IconExtensionTest.php
+++ b/tests/IconExtensionTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Twig\Extensions\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Twig\Extensions\IconExtension;
+
+class IconExtensionTest extends TestCase
+{
+    public function testIconFont(): void
+    {
+        $iconExtension = new IconExtension('font');
+
+        $this->assertSame(
+            '<span class="icon icon-test"></span>',
+            $iconExtension->getIcon('test')
+        );
+    }
+
+    public function testFalseIconSet(): void
+    {
+        $iconExtension = new IconExtension([
+            'default' => 'font',
+            'special' => 'font',
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Icon Set with name "other" not found, found: "default", "special".');
+
+        $iconExtension->getIcon('test', null, 'other');
+    }
+
+    public function testIconFontCustomSettings(): void
+    {
+        $iconExtension = new IconExtension([
+            'other' => [
+                'type' => 'font',
+                'className' => 'my-icon',
+                'classPrefix' => 'my-icon-',
+                'classSuffix' => '-new',
+            ],
+        ]);
+
+        $this->assertSame(
+            '<span class="add-class my-icon my-icon-test-new"></span>',
+            $iconExtension->getIcon('test', 'add-class', 'other')
+        );
+    }
+
+    public function testSvgIcon(): void
+    {
+        $iconExtension = new IconExtension([
+            'default' => [
+                'type' => 'svg',
+                'path' => '/path/to/symbol-defs.svg',
+            ],
+        ]);
+
+        $this->assertSame(
+            '<svg class="icon icon-test"><use xlink:href="/path/to/symbol-defs.svg#test"></use></svg>',
+            $iconExtension->getIcon('test')
+        );
+    }
+
+    public function testSvgIconCustomSettings(): void
+    {
+        $iconExtension = new IconExtension([
+            'other' => [
+                'type' => 'svg',
+                'path' => '/path/to/symbol-defs.svg',
+                'className' => 'my-icon',
+                'classPrefix' => 'my-icon-',
+                'classSuffix' => '-new',
+            ],
+        ]);
+
+        $this->assertSame(
+            '<svg class="add-class my-icon my-icon-test-new"><use xlink:href="/path/to/symbol-defs.svg#test"></use></svg>',
+            $iconExtension->getIcon('test', 'add-class', 'other')
+        );
+    }
+}


### PR DESCRIPTION
The new icon twig extension allow to output icomoon icons in different formats based on given configuration:


```yaml
services:
    Sulu\Twig\Extensions\IconExtension: ~
```

Or a more complex configuration example:

```yaml
services:
    Sulu\Twig\Extensions\IconExtension:
        arguments:
            $iconSets:
                # icon font:
                default:
                    type: 'font'
                    # the following options are optional but need to match your icomoon export settings:
                    # className: 'icon' 
                    # classPrefix: 'icon-' 
                    # classSuffix: ''
                # svg icons:
                other:
                    type: 'svg'
                    path: '/website/fonts/icomoon-sulu/symbol-defs.svg'
                    # the following options are optional but need to match your icomoon export settings:
                    # className: 'icon' 
                    # classPrefix: 'icon-' 
                    # classSuffix: ''
```
