### PR TITLE
Add additional attributes to icon extension

### DIFF
--- a/docs/icon.md
+++ b/docs/icon.md
@@ -34,6 +34,8 @@ services:
                     # className: 'icon' 
                     # classPrefix: 'icon-' 
                     # classSuffix: ''
+            $defaultAttributes:
+                role: 'none'
 ```
 
 ## Usage
@@ -133,4 +135,36 @@ As you see above the format for the classes is the following:
 
 ```
 {additionaClass} {className} {classPrefix}{icon}{classSuffix}
+```
+
+### Add additional attributes
+
+Not only a class can be passed you can also add any other attributes:
+
+```twig
+<!-- Icon Font -->
+{{ get_icon('test', { role: 'none'}) }}
+
+<!-- SVG Icons -->
+{{ get_icon('test', { role: 'none'}, 'other') }}
+```
+
+This will output:
+
+```html
+<!-- Icon Font -->
+<span role="none" class="icon icon-test"></span>
+
+<!-- SVG Icons -->
+<svg role="none" class="icon icon-test"><use xlink:href="/path/to/symbol-defs.svg#test"></use></svg>
+```
+
+You can also configure default attributes in the service registration the following way:
+
+```yaml
+services:
+    Sulu\Twig\Extensions\IconExtension:
+        arguments:
+            $defaultAttributes:
+                role: 'none'
 ```

--- a/docs/icon.md
+++ b/docs/icon.md
@@ -8,13 +8,27 @@ The twig extension need to be registered as [symfony service](http://symfony.com
 
 ```yaml
 services:
+    Sulu\Twig\Extensions\IconExtension: ~
+```
+
+Or a more complex configuration example:
+
+```yaml
+services:
     Sulu\Twig\Extensions\IconExtension:
         arguments:
             $iconSets:
+                # icon font:
                 default:
-                    type: 'font' # or 'svg'
-                    # for svg also a path to symbol-defs file is needed:
-                    # path: '/website/fonts/icomoon-sulu/symbol-defs.svg'
+                    type: 'font'
+                    # the following options are optional but need to match your icomoon export settings:
+                    # className: 'icon'
+                    # classPrefix: 'icon-'
+                    # classSuffix: ''
+                # svg icons:
+                other:
+                    type: 'svg'
+                    path: '/website/fonts/icomoon-sulu/symbol-defs.svg'
 
                     # the following options are optional but need to match your icomoon export settings:
                     # className: 'icon' 
@@ -29,6 +43,7 @@ services:
 ```yaml
 services:
     Sulu\Twig\Extensions\IconExtension:
+        # the following configuration is default
         arguments:
             $iconSets:
                 default:

--- a/src/IconExtension.php
+++ b/src/IconExtension.php
@@ -32,7 +32,7 @@ class IconExtension extends AbstractExtension
     /**
      * @param string|mixed[] $iconSets
      */
-    public function __construct($iconSets)
+    public function __construct($iconSets = self::ICON_SET_TYPE_FONT)
     {
         if (\is_string($iconSets)) {
             $iconSets = [

--- a/tests/IconExtensionTest.php
+++ b/tests/IconExtensionTest.php
@@ -41,6 +41,36 @@ class IconExtensionTest extends TestCase
         $iconExtension->getIcon('test', null, 'other');
     }
 
+    public function testIconFontDefaultAttributes(): void
+    {
+        $iconExtension = new IconExtension('font', ['role' => 'none']);
+
+        $this->assertSame(
+            '<span role="none" class="icon icon-test"></span>',
+            $iconExtension->getIcon('test')
+        );
+    }
+
+    public function testIconFontRemoveDefaultAttributes(): void
+    {
+        $iconExtension = new IconExtension('font', ['role' => 'none']);
+
+        $this->assertSame(
+            '<span class="icon icon-test"></span>',
+            $iconExtension->getIcon('test', ['role' => null])
+        );
+    }
+
+    public function testIconFontAttributes(): void
+    {
+        $iconExtension = new IconExtension('font');
+
+        $this->assertSame(
+            '<span role="none" class="icon icon-test"></span>',
+            $iconExtension->getIcon('test', ['role' => 'none'])
+        );
+    }
+
     public function testIconFontCustomSettings(): void
     {
         $iconExtension = new IconExtension([
@@ -55,6 +85,20 @@ class IconExtensionTest extends TestCase
         $this->assertSame(
             '<span class="add-class my-icon my-icon-test-new"></span>',
             $iconExtension->getIcon('test', 'add-class', 'other')
+        );
+    }
+
+    public function testIconFontOtherGroup(): void
+    {
+        $iconExtension = new IconExtension([
+            'other' => [
+                'type' => 'font',
+            ],
+        ]);
+
+        $this->assertSame(
+            '<span class="icon icon-test"></span>',
+            $iconExtension->getIcon('test', null, 'other')
         );
     }
 
@@ -73,6 +117,61 @@ class IconExtensionTest extends TestCase
         );
     }
 
+    public function testSvgIconAttributes(): void
+    {
+        $iconExtension = new IconExtension([
+            'default' => [
+                'type' => 'svg',
+                'path' => '/path/to/symbol-defs.svg',
+            ],
+        ]);
+
+        $this->assertSame(
+            '<svg role="none" class="icon icon-test"><use xlink:href="/path/to/symbol-defs.svg#test"></use></svg>',
+            $iconExtension->getIcon('test', ['role' => 'none'])
+        );
+    }
+
+    public function testSvgIconDefaultAttributes(): void
+    {
+        $iconExtension = new IconExtension(
+            [
+                'default' => [
+                    'type' => 'svg',
+                    'path' => '/path/to/symbol-defs.svg',
+                ],
+            ],
+            [
+                'role' => 'none',
+            ]
+        );
+
+        $this->assertSame(
+            '<svg role="none" class="icon icon-test"><use xlink:href="/path/to/symbol-defs.svg#test"></use></svg>',
+            $iconExtension->getIcon('test')
+        );
+    }
+
+    public function testSvgIconRemoveDefaultAttributes(): void
+    {
+        $iconExtension = new IconExtension(
+            [
+                'default' => [
+                    'type' => 'svg',
+                    'path' => '/path/to/symbol-defs.svg',
+                ],
+            ],
+            [
+                'role' => 'none',
+            ]
+        );
+
+        $this->assertSame(
+            '<svg class="icon icon-test"><use xlink:href="/path/to/symbol-defs.svg#test"></use></svg>',
+            $iconExtension->getIcon('test', ['role' => null])
+        );
+    }
+
     public function testSvgIconCustomSettings(): void
     {
         $iconExtension = new IconExtension([
@@ -88,6 +187,21 @@ class IconExtensionTest extends TestCase
         $this->assertSame(
             '<svg class="add-class my-icon my-icon-test-new"><use xlink:href="/path/to/symbol-defs.svg#test"></use></svg>',
             $iconExtension->getIcon('test', 'add-class', 'other')
+        );
+    }
+
+    public function testSvgIconOtherGroup(): void
+    {
+        $iconExtension = new IconExtension([
+            'other' => [
+                'type' => 'svg',
+                'path' => '/path/to/symbol-defs.svg',
+            ],
+        ]);
+
+        $this->assertSame(
+            '<svg class="icon icon-test"><use xlink:href="/path/to/symbol-defs.svg#test"></use></svg>',
+            $iconExtension->getIcon('test', null, 'other')
         );
     }
 }


### PR DESCRIPTION
Now not only the `class` can be set of the icon also accessibility attributes e.g.:

```twig
{{ get_icon('test', { role: 'none' }) }}
```

```html
<span class="icon icon-test" role="none"></span>
```

Also the service registration of the icon twig extension has been simplified by using and will default font implementation:

```yaml
services:
    Sulu\Twig\Extensions\IconExtension: ~
```