### PR TITLE
Rename register component twig function to prepare

### DIFF
--- a/docs/component.md
+++ b/docs/component.md
@@ -20,8 +20,8 @@ If autoconfigure is not active you need to tag it with [twig.extension](https://
 
 ## Usage
 
-Every component is represented by a DOM element the `prepare_component` function will generate a unique id
-which need to set on the DOM element.
+Every component is assigned to a DOM element. The `prepare_component` function will generate a unique id
+which needs to be set to the DOM element.
 
 At the bottom of your HTML Document you call the [web-js](https://github.com/sulu/web-js) functions
 to start the components you have prepared before.

--- a/docs/component.md
+++ b/docs/component.md
@@ -23,8 +23,7 @@ If autoconfigure is not active you need to tag it with [twig.extension](https://
 Every component is assigned to a DOM element. The `prepare_component` function will generate a unique id
 which needs to be set to the DOM element.
 
-At the bottom of your HTML Document you call the [web-js](https://github.com/sulu/web-js) functions
-to start the components you have prepared before.
+To start the prepared components, you need to call [web-js](https://github.com/sulu/web-js) functions at the bottom of your HTML Document.
 
 With the `component_list` twig function you can also add only specific html when really needed.
 

--- a/docs/component.md
+++ b/docs/component.md
@@ -81,8 +81,8 @@ If you don't want to autogenerate an ID you can give it as an option:
 
 ### Handling ESI
 
-As ESI are own sub request which does not know about the main request ESI need to be handled special.
-So if you want to use `web-js` components inside ESI you need to add the following to your `base.html.twig`.
+An ESI request is a separate sub request that does not know anything about the main request. To prevent conflicts, components need to be handled differently inside of ESI requests.
+If you want to use a `web-js` component inside of a ESI request, you need to add the following to your `base.html.twig`:
 
 ```twig
 <head>

--- a/docs/component.md
+++ b/docs/component.md
@@ -38,6 +38,13 @@ With the `component_list` twig function you can also add only specific html when
     Say Hello
 </button>
 
+{# Output html that is only needed if a specific component was prepared #}	
+{% if 'component' in get_component_list() %}	
+    <script id="component-template" type="text/html">	
+        <div>Template</div>	
+    </script>	
+{% endif %}
+
 {# Start components and run service functions #}
 <script>
     web.startComponents({{ get_components() }});

--- a/src/ComponentExtension.php
+++ b/src/ComponentExtension.php
@@ -72,7 +72,7 @@ class ComponentExtension extends AbstractExtension
     {
         @trigger_error(
             __METHOD__ . ' is deprecated and will be removed in sulu/web-twig 3.0 use "prepareComponent" instead.',
-            E_USER_DEPRECATED
+            \E_USER_DEPRECATED
         );
 
         return $this->prepareComponent($name, $options, $prefix);
@@ -168,7 +168,7 @@ class ComponentExtension extends AbstractExtension
     {
         @trigger_error(
             __METHOD__ . ' is deprecated and will be removed in sulu/web-twig 3.0 use "prepareService" instead.',
-            E_USER_DEPRECATED
+            \E_USER_DEPRECATED
         );
 
         $this->prepareService($name, $function, $parameters);

--- a/src/ComponentExtension.php
+++ b/src/ComponentExtension.php
@@ -47,10 +47,12 @@ class ComponentExtension extends AbstractExtension
     public function getFunctions()
     {
         return [
-            new TwigFunction('register_component', [$this, 'registerComponent']),
+            new TwigFunction('register_component', [$this, 'registerComponent'], ['deprecated' => true]),
+            new TwigFunction('prepare_component', [$this, 'prepareComponent']),
             new TwigFunction('get_components', [$this, 'getComponents'], ['is_safe' => ['html']]),
             new TwigFunction('get_component_list', [$this, 'getComponentList'], ['is_safe' => ['html']]),
             new TwigFunction('call_service', [$this, 'callService']),
+            new TwigFunction('prepare_service', [$this, 'prepareService'], ['deprecated' => true]),
             new TwigFunction('get_services', [$this, 'getServices'], ['is_safe' => ['html']]),
             new TwigFunction('get_service_list', [$this, 'getServiceList'], ['is_safe' => ['html']]),
             new TwigFunction('set_component_prefix', [$this, 'setComponentPrefix']),
@@ -58,7 +60,7 @@ class ComponentExtension extends AbstractExtension
     }
 
     /**
-     * Register a new component and get a unique id.
+     * Prepare a new component and get a unique id.
      *
      * @param string $name
      * @param mixed[]|null $options
@@ -67,6 +69,25 @@ class ComponentExtension extends AbstractExtension
      * @return string
      */
     public function registerComponent(string $name, ?array $options = null, ?string $prefix = ''): string
+    {
+        @trigger_error(
+            __METHOD__ . ' is deprecated and will be removed in sulu/web-twig 3.0 use "prepareComponent" instead.',
+            E_USER_DEPRECATED
+        );
+
+        return $this->prepareComponent($name, $options, $prefix);
+    }
+
+    /**
+     * Prepare a new component and get a unique id.
+     *
+     * @param string $name
+     * @param mixed[]|null $options
+     * @param string $prefix
+     *
+     * @return string
+     */
+    public function prepareComponent(string $name, ?array $options = null, ?string $prefix = ''): string
     {
         if (!isset($this->instanceCounter[$name])) {
             $this->instanceCounter[$name] = 0;
@@ -137,13 +158,30 @@ class ComponentExtension extends AbstractExtension
     }
 
     /**
-     * Call a service function.
+     * Prepare a service call.
      *
      * @param string $name
      * @param string $function
      * @param mixed[] $parameters
      */
     public function callService(string $name, string $function, array $parameters = []): void
+    {
+        @trigger_error(
+            __METHOD__ . ' is deprecated and will be removed in sulu/web-twig 3.0 use "prepareService" instead.',
+            E_USER_DEPRECATED
+        );
+
+        $this->prepareService($name, $function, $parameters);
+    }
+
+    /**
+     * Prepare a service call.
+     *
+     * @param string $name
+     * @param string $function
+     * @param mixed[] $parameters
+     */
+    public function prepareService(string $name, string $function, array $parameters = []): void
     {
         $this->services[] = [
             'name' => $name,

--- a/tests/Unit/ComponentExtensionTest.php
+++ b/tests/Unit/ComponentExtensionTest.php
@@ -30,7 +30,7 @@ class ComponentExtensionTest extends TestCase
 
     public function testRegisterComponent(): void
     {
-        $this->assertSame('test-1', $this->componentExtension->registerComponent('test'));
+        $this->assertSame('test-1', $this->componentExtension->prepareComponent('test'));
 
         $components = $this->componentExtension->getComponents();
         $this->assertNotFalse($components);
@@ -48,7 +48,8 @@ class ComponentExtensionTest extends TestCase
 
     public function testRegisterMultipleComponent(): void
     {
-        $this->assertSame('test-1', $this->componentExtension->registerComponent('test'));
+        $this->assertSame('test-1', $this->componentExtension->prepareComponent('test'));
+        // this deprecated registerComponent function
         $this->assertSame('test-2', $this->componentExtension->registerComponent('test'));
 
         $components = $this->componentExtension->getComponents();
@@ -73,8 +74,8 @@ class ComponentExtensionTest extends TestCase
     public function testRegisterPrefix(): void
     {
         $this->componentExtension->setComponentPrefix('partial-');
-        $this->assertSame('partial-test-1', $this->componentExtension->registerComponent('test'));
-        $this->assertSame('partial-test-2', $this->componentExtension->registerComponent('test'));
+        $this->assertSame('partial-test-1', $this->componentExtension->prepareComponent('test'));
+        $this->assertSame('partial-test-2', $this->componentExtension->prepareComponent('test'));
 
         $components = $this->componentExtension->getComponents();
         $this->assertNotFalse($components);
@@ -97,7 +98,7 @@ class ComponentExtensionTest extends TestCase
 
     public function testRegisterCustomIdComponent(): void
     {
-        $this->assertSame('custom', $this->componentExtension->registerComponent('test', ['id' => 'custom']));
+        $this->assertSame('custom', $this->componentExtension->prepareComponent('test', ['id' => 'custom']));
         $components = $this->componentExtension->getComponents();
         $this->assertNotFalse($components);
         $this->assertSame(
@@ -114,7 +115,7 @@ class ComponentExtensionTest extends TestCase
 
     public function testRegisterOptionComponent(): void
     {
-        $this->assertSame('test-1', $this->componentExtension->registerComponent('test', ['option1' => 'value1', 'option2' => 'value2']));
+        $this->assertSame('test-1', $this->componentExtension->prepareComponent('test', ['option1' => 'value1', 'option2' => 'value2']));
 
         $components = $this->componentExtension->getComponents();
         $this->assertNotFalse($components);
@@ -135,7 +136,7 @@ class ComponentExtensionTest extends TestCase
 
     public function testRegisterComponentArray(): void
     {
-        $this->assertSame('test-1', $this->componentExtension->registerComponent('test'));
+        $this->assertSame('test-1', $this->componentExtension->prepareComponent('test'));
 
         /** @var array<int, array{name: string, id: string, options: mixed}> $components */
         $components = $this->componentExtension->getComponents(false);
@@ -156,7 +157,7 @@ class ComponentExtensionTest extends TestCase
 
     public function testRegisterComponentClear(): void
     {
-        $this->assertSame('test-1', $this->componentExtension->registerComponent('test'));
+        $this->assertSame('test-1', $this->componentExtension->prepareComponent('test'));
 
         // Get components without clearing them.
         $components = $this->componentExtension->getComponents(true, false);
@@ -192,10 +193,10 @@ class ComponentExtensionTest extends TestCase
 
     public function testComponentList(): void
     {
-        $this->componentExtension->registerComponent('test');
-        $this->componentExtension->registerComponent('test');
-        $this->componentExtension->registerComponent('test2');
-        $this->componentExtension->registerComponent('test3');
+        $this->componentExtension->prepareComponent('test');
+        $this->componentExtension->prepareComponent('test');
+        $this->componentExtension->prepareComponent('test2');
+        $this->componentExtension->prepareComponent('test3');
 
         $componentList = $this->componentExtension->getComponentList();
 
@@ -206,7 +207,7 @@ class ComponentExtensionTest extends TestCase
 
     public function testCallService(): void
     {
-        $this->componentExtension->callService('service', 'function', ['key' => 'value']);
+        $this->componentExtension->prepareService('service', 'function', ['key' => 'value']);
 
         $this->assertSame(
             json_encode([
@@ -224,9 +225,10 @@ class ComponentExtensionTest extends TestCase
 
     public function testGetServices(): void
     {
-        $this->componentExtension->callService('service', 'function', ['key' => 'value']);
-        $this->componentExtension->callService('service2', 'function', ['key' => 'value']);
-        $this->componentExtension->callService('service2', 'function', ['key' => 'value']);
+        $this->componentExtension->prepareService('service', 'function', ['key' => 'value']);
+        $this->componentExtension->prepareService('service2', 'function', ['key' => 'value']);
+        $this->componentExtension->prepareService('service2', 'function', ['key' => 'value']);
+        // test deprecated service call
         $this->componentExtension->callService('service3', 'function', ['key' => 'value']);
 
         $servicesList = $this->componentExtension->getServiceList();

--- a/tests/Unit/ComponentExtensionTest.php
+++ b/tests/Unit/ComponentExtensionTest.php
@@ -23,7 +23,7 @@ class ComponentExtensionTest extends TestCase
      */
     private $componentExtension;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->componentExtension = new ComponentExtension();
     }

--- a/tests/Unit/ComponentExtensionTest.php
+++ b/tests/Unit/ComponentExtensionTest.php
@@ -49,7 +49,7 @@ class ComponentExtensionTest extends TestCase
     public function testPrepareMultipleComponent(): void
     {
         $this->assertSame('test-1', $this->componentExtension->prepareComponent('test'));
-        // this deprecated registerComponent function
+        // test deprecated registerComponent function
         $this->assertSame('test-2', $this->componentExtension->registerComponent('test'));
 
         $components = $this->componentExtension->getComponents();

--- a/tests/Unit/ComponentExtensionTest.php
+++ b/tests/Unit/ComponentExtensionTest.php
@@ -28,7 +28,7 @@ class ComponentExtensionTest extends TestCase
         $this->componentExtension = new ComponentExtension();
     }
 
-    public function testRegisterComponent(): void
+    public function testPrepareComponent(): void
     {
         $this->assertSame('test-1', $this->componentExtension->prepareComponent('test'));
 
@@ -46,7 +46,7 @@ class ComponentExtensionTest extends TestCase
         );
     }
 
-    public function testRegisterMultipleComponent(): void
+    public function testPrepareMultipleComponent(): void
     {
         $this->assertSame('test-1', $this->componentExtension->prepareComponent('test'));
         // this deprecated registerComponent function
@@ -71,7 +71,7 @@ class ComponentExtensionTest extends TestCase
         );
     }
 
-    public function testRegisterPrefix(): void
+    public function testPreparePrefix(): void
     {
         $this->componentExtension->setComponentPrefix('partial-');
         $this->assertSame('partial-test-1', $this->componentExtension->prepareComponent('test'));
@@ -96,7 +96,7 @@ class ComponentExtensionTest extends TestCase
         );
     }
 
-    public function testRegisterCustomIdComponent(): void
+    public function testPrepareCustomIdComponent(): void
     {
         $this->assertSame('custom', $this->componentExtension->prepareComponent('test', ['id' => 'custom']));
         $components = $this->componentExtension->getComponents();
@@ -113,7 +113,7 @@ class ComponentExtensionTest extends TestCase
         );
     }
 
-    public function testRegisterOptionComponent(): void
+    public function testPrepareOptionComponent(): void
     {
         $this->assertSame('test-1', $this->componentExtension->prepareComponent('test', ['option1' => 'value1', 'option2' => 'value2']));
 
@@ -134,7 +134,7 @@ class ComponentExtensionTest extends TestCase
         );
     }
 
-    public function testRegisterComponentArray(): void
+    public function testPrepareComponentArray(): void
     {
         $this->assertSame('test-1', $this->componentExtension->prepareComponent('test'));
 
@@ -155,7 +155,7 @@ class ComponentExtensionTest extends TestCase
         );
     }
 
-    public function testRegisterComponentClear(): void
+    public function testPrepareComponentClear(): void
     {
         $this->assertSame('test-1', $this->componentExtension->prepareComponent('test'));
 
@@ -205,7 +205,7 @@ class ComponentExtensionTest extends TestCase
         $this->assertSame(['test', 'test2', 'test3'], $componentList);
     }
 
-    public function testCallService(): void
+    public function testPrepareService(): void
     {
         $this->componentExtension->prepareService('service', 'function', ['key' => 'value']);
 
@@ -223,7 +223,7 @@ class ComponentExtensionTest extends TestCase
         );
     }
 
-    public function testGetServices(): void
+    public function testPrepareServices(): void
     {
         $this->componentExtension->prepareService('service', 'function', ['key' => 'value']);
         $this->componentExtension->prepareService('service2', 'function', ['key' => 'value']);

--- a/tests/Unit/CountExtensionTest.php
+++ b/tests/Unit/CountExtensionTest.php
@@ -23,7 +23,7 @@ class CountExtensionTest extends TestCase
      */
     private $countExtension;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->countExtension = new CountExtension();
     }

--- a/tests/Unit/EditorExtensionTest.php
+++ b/tests/Unit/EditorExtensionTest.php
@@ -23,7 +23,7 @@ class EditorExtensionTest extends TestCase
      */
     private $editorExtension;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->editorExtension = new EditorExtension();
     }

--- a/tests/Unit/ImageExtensionTest.php
+++ b/tests/Unit/ImageExtensionTest.php
@@ -33,7 +33,7 @@ class ImageExtensionTest extends TestCase
      */
     private $svgImage;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->imageExtension = new ImageExtension('/lazy');
         $this->image = [

--- a/tests/Unit/IntlExtensionTest.php
+++ b/tests/Unit/IntlExtensionTest.php
@@ -24,7 +24,7 @@ class IntlExtensionTest extends TestCase
      */
     private $intlExtension;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->intlExtension = new IntlExtension();
     }

--- a/tests/Unit/PortalExtensionTest.php
+++ b/tests/Unit/PortalExtensionTest.php
@@ -23,7 +23,7 @@ class PortalExtensionTest extends TestCase
      */
     private $portalExtension;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->portalExtension = new PortalExtension();
     }

--- a/tests/Unit/UrlExtensionTest.php
+++ b/tests/Unit/UrlExtensionTest.php
@@ -25,7 +25,7 @@ class UrlExtensionTest extends TestCase
      */
     private $urlExtension;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->urlExtension = new UrlExtension();
     }


### PR DESCRIPTION
Fixes #29

This will rename the following functions

`register_component` -> `prepare_component`
`call_service` -> `prepare_service`