### PR TITLE
Add option to guess and calculate width and height for an image format

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -25,7 +25,7 @@ Sulu\Twig\Extensions\ImageExtension:
         $defaultAdditionalTypes:
             webp: 'image/webp'
         $aspectRatio: true
-        $imageFormatConfiguration: '%sulu_media.image.formats''
+        $imageFormatConfiguration: '%sulu_media.image.formats%'
 ```
 
 ## Usage
@@ -272,5 +272,5 @@ The feature will automatically add a width and height attribute to the rendered 
 ```
 
 The `$imageFormatConfiguration` parameter is optional. Without it will try to
-guess the format by the given format key so it will then only work with format keys
+guess the format by the given format key. It will then only work with format keys
 like 100x, x100, 100x@2x, 100x100-inset and similars.

--- a/docs/image.md
+++ b/docs/image.md
@@ -271,6 +271,6 @@ The feature will automatically add a width and height attribute to the rendered 
 <img alt="Title" title="Description" src="/uploads/media/100x/01/image.jpg?v=1-0" width="'100" height="56">
 ```
 
-The `$imageFormatConfiguration` parameter is optional. Without it will try to
-guess the format by the given format key. It will then only work with format keys
-like 100x, x100, 100x@2x, 100x100-inset and similars.
+The `$imageFormatConfiguration` parameter is optional. If it is not set, the extension
+tries to guess the dimensions by the given format key. This will only work for format keys
+in the format of 100x, x100, 100x@2x and 100x100-inset.

--- a/docs/image.md
+++ b/docs/image.md
@@ -15,6 +15,19 @@ services:
 
 If autoconfigure is not active you need to tag it with [twig.extension](https://symfony.com/doc/current/service_container.html#the-autoconfigure-option).
 
+**Recommended Configuration**
+
+```yaml
+Sulu\Twig\Extensions\ImageExtension:
+    arguments:
+        $defaultAttributes:
+            loading: 'lazy'
+        $defaultAdditionalTypes:
+            webp: 'image/webp'
+        $aspectRatio: true
+        $imageFormatConfiguration: '%sulu_media.image.formats''
+```
+
 ## Usage
 
 #### Get an image
@@ -242,7 +255,8 @@ This feature can be activated the following way:
 services:
     Sulu\Twig\Extensions\ImageExtension:
         arguments:
-            $guessAspectRatio: true
+            $aspectRatio: true
+            $imageFormatConfiguration: '%sulu_media.image.formats%' # optional but recommended
 ```
 
 So if we have an original image of 1920x1080 and have a image format called 100x:
@@ -257,5 +271,6 @@ Will add automatically the width and height attributes to the imgage tag:
 <img alt="Title" title="Description" src="/uploads/media/100x/01/image.jpg?v=1-0" width="'100" height="56">
 ```
 
-This only works when writing image formats in specific format 100x, x100, 100x100, 100x100-inset, 100x@2x, ...
-for all other cases this option not be activated.
+The is recommend `sulu_media.image.formats` but is optional. Without it will try to
+guess the format by the given format key so it will then only work with format keys
+like 100x, x100, 100x@2x, 100x100-inset and similars.

--- a/docs/image.md
+++ b/docs/image.md
@@ -227,3 +227,35 @@ You can also only activate it for a specific call:
     '(max-width: 650px)': 'sulu-100x100',
 }, { webp: 'image/webp' }) }}
 ```
+
+##### 8. Set width and height attribute automatically
+
+Since Sulu 2.3 the original image width and height are save as properties.
+This allows us the guess the width and height dimension of a given image format.
+
+With setting the width and height attribute modern browsers avoid a layer shifts
+and the page will not jump when images are loaded.
+
+This feature can be activated the following way:
+
+```yaml
+services:
+    Sulu\Twig\Extensions\ImageExtension:
+        arguments:
+            $guessAspectRatio: true
+```
+
+So if we have an original image of 1920x1080 and have a image format called 100x:
+
+```twig
+{{ get_image(headerImage, '100x') }}
+```
+
+Will add automatically the width and height attributes to the imgage tag:
+
+```twig
+<img alt="Title" title="Description" src="/uploads/media/100x/01/image.jpg?v=1-0" width="'100" height="56">
+```
+
+This only works when writing image formats in specific format 100x, x100, 100x100, 100x100-inset, 100x@2x, ...
+for all other cases this option not be activated.

--- a/docs/image.md
+++ b/docs/image.md
@@ -243,11 +243,11 @@ You can also only activate it for a specific call:
 
 ##### 8. Set width and height attribute automatically
 
-Since Sulu 2.3 the original image width and height are save as properties.
-This allows us the guess the width and height dimension of a given image format.
+Since Sulu 2.3 the original image width and height are saved as properties.
+This allows to guess the width and height of a image format and set the respective HTML attributes.
 
-With setting the width and height attribute modern browsers avoid a layer shifts
-and the page will not jump when images are loaded.
+Setting the width and height attribute allows modern browsers to avoid layer shifts
+and therefore the page will not jump when images are loaded.
 
 This feature can be activated the following way:
 
@@ -259,18 +259,18 @@ services:
             $imageFormatConfiguration: '%sulu_media.image.formats%' # optional but recommended
 ```
 
-So if we have an original image of 1920x1080 and have a image format called 100x:
+For example, if the original image has a resolution of 1920x1080 and the image format is called 100x:
 
 ```twig
 {{ get_image(headerImage, '100x') }}
 ```
 
-Will add automatically the width and height attributes to the imgage tag:
+The feature will automatically add a width and height attribute to the rendered image tag:
 
 ```twig
 <img alt="Title" title="Description" src="/uploads/media/100x/01/image.jpg?v=1-0" width="'100" height="56">
 ```
 
-The is recommend `sulu_media.image.formats` but is optional. Without it will try to
+The `$imageFormatConfiguration` parameter is optional. Without it will try to
 guess the format by the given format key so it will then only work with format keys
 like 100x, x100, 100x@2x, 100x100-inset and similars.

--- a/src/ImageExtension.php
+++ b/src/ImageExtension.php
@@ -423,7 +423,7 @@ class ImageExtension extends AbstractExtension
 
     /**
      * @param mixed $media
-     * @param array<string, string|null>|string $attributes
+     * @param array<string, string|null> $attributes
      *
      * @return array{
      *     0: int|null,
@@ -461,11 +461,12 @@ class ImageExtension extends AbstractExtension
         if ($isInset && $width && $height) {
             // calculate inset width and height e.g. 200x50-inset, 100x100-inset
             $insetWidth = $width;
-            if ($width && $originalWidth > $width) {
+            $insetHeight = $height;
+            if ($originalWidth > $width) {
                 $insetHeight = $originalHeight / $originalWidth * $width;
             }
 
-            if ($height && round($insetHeight) > $height) {
+            if (round($insetHeight) > $height) {
                 $insetHeight = $height;
                 $insetWidth = $originalWidth / $originalHeight * $height;
             }
@@ -474,11 +475,11 @@ class ImageExtension extends AbstractExtension
         }
 
         // calculate the not given dimension parameter
-        if (!$width && is_numeric($height)) {
+        if (!$width) {
             $width = $originalWidth / $originalHeight * $height;
         }
 
-        if (!$height && is_numeric($width)) {
+        if (!$height) {
             $height = $originalHeight / $originalWidth * $width;
         }
 

--- a/src/ImageExtension.php
+++ b/src/ImageExtension.php
@@ -71,13 +71,28 @@ class ImageExtension extends AbstractExtension
     private $aspectRatio = false;
 
     /**
-     * @var mixed[]|null
+     * @var array<string, array{
+     *     scale: array{
+     *         x: int|null,
+     *         y: int|null,
+     *         mode: int,
+     *         retina: bool,
+     *     },
+     * }>|null
      */
     private $imageFormatConfiguration = null;
 
     /**
      * @param string[] $defaultAttributes
      * @param string[] $defaultAdditionalTypes
+     * @param array<string, array{
+     *     scale: array{
+     *         x: int|null,
+     *         y: int|null,
+     *         mode: int,
+     *         retina: bool,
+     *     },
+     * }>|null $imageFormatConfiguration
      */
     public function __construct(
         ?string $placeholderPath = null,
@@ -446,7 +461,7 @@ class ImageExtension extends AbstractExtension
             $isInset = \in_array($this->imageFormatConfiguration[$src]['scale']['mode'], [
                 1,
                 'inset',
-            ]);
+            ], true);
             $x = $this->imageFormatConfiguration[$src]['scale']['x'];
             $y = $this->imageFormatConfiguration[$src]['scale']['y'];
             $width = $x ? (int) round($x * $scale) : null;

--- a/tests/Unit/ImageExtensionTest.php
+++ b/tests/Unit/ImageExtensionTest.php
@@ -500,7 +500,10 @@ class ImageExtensionTest extends TestCase
         );
     }
 
-    public function testGuessRatioWidthAndHeight(): void
+    /**
+     * @dataProvider guessRatioDataProvider
+     */
+    public function testGuessAspectRatio(string $format, string $expectedWidth, string $expectedHeight): void
     {
         $imageExtension = new ImageExtension(null, [], [], true);
 
@@ -508,141 +511,43 @@ class ImageExtensionTest extends TestCase
             $this->image,
             [
                 'thumbnails' => [
-                    '100x100' => '/uploads/media/100x100/01/image.jpg?v=1-0',
-                    '100x100.webp' => '/uploads/media/100x100/01/image.webp?v=1-0',
+                    $format => '/uploads/media/' . $format . '/01/image.jpg?v=1-0',
+                    $format . '.webp' => '/uploads/media/' . $format . '/01/image.webp?v=1-0',
                 ],
             ],
         );
 
         $this->assertSame(
-            '<img alt="Title" title="Description" src="/uploads/media/100x100/01/image.jpg?v=1-0" width="100" height="100">',
-            $imageExtension->getImage($image, '100x100')
+            '<img alt="Title" title="Description" src="/uploads/media/' . $format . '/01/image.jpg?v=1-0" width="' . $expectedWidth . '" height="' . $expectedHeight . '">',
+            $imageExtension->getImage($image, $format)
         );
     }
 
-    public function testGuessRatioOnlyWidth(): void
+    public function guessRatioDataProvider(): \Generator
     {
-        $imageExtension = new ImageExtension(null, [], [], true);
-
-        $image = $this->image;
-        $image['thumbnails']['100x'] = '/uploads/media/100x/01/image.jpg?v=1-0';
-        $image['thumbnails']['100x.webp'] = '/uploads/media/100x/01/image.webp?v=1-0';
-
-        $this->assertSame(
-            '<img alt="Title" title="Description" src="/uploads/media/100x/01/image.jpg?v=1-0" width="100" height="56">',
-            $imageExtension->getImage($image, '100x')
-        );
-    }
-
-    public function testGuessRatioOnlyHeight(): void
-    {
-        $imageExtension = new ImageExtension(null, [], [], true);
-
-        $image = $this->image;
-        $image['thumbnails']['x100'] = '/uploads/media/x100/01/image.jpg?v=1-0';
-        $image['thumbnails']['x100.webp'] = '/uploads/media/x100/01/image.webp?v=1-0';
-
-        $this->assertSame(
-            '<img alt="Title" title="Description" src="/uploads/media/x100/01/image.jpg?v=1-0" width="178" height="100">',
-            $imageExtension->getImage($image, 'x100')
-        );
-    }
-
-    public function testGuessRatioOnlyWidthWithAt2(): void
-    {
-        $imageExtension = new ImageExtension(null, [], [], true);
-
-        $image = $this->image;
-        $image['thumbnails']['100x@2x'] = '/uploads/media/100x@2x/01/image.jpg?v=1-0';
-        $image['thumbnails']['100x@2x.webp'] = '/uploads/media/100x@2x/01/image.webp?v=1-0';
-
-        $this->assertSame(
-            '<img alt="Title" title="Description" src="/uploads/media/100x@2x/01/image.jpg?v=1-0" width="100" height="56">',
-            $imageExtension->getImage($image, '100x@2x')
-        );
-    }
-
-    public function testGuessRatioOnlyWidthWithInset(): void
-    {
-        $imageExtension = new ImageExtension(null, [], [], true);
-
-        $image = $this->image;
-        $image['thumbnails']['100x-inset'] = '/uploads/media/100x-inset/01/image.jpg?v=1-0';
-        $image['thumbnails']['100x-inset.webp'] = '/uploads/media/100x-inset/01/image.webp?v=1-0';
-
-        $this->assertSame(
-            '<img alt="Title" title="Description" src="/uploads/media/100x-inset/01/image.jpg?v=1-0" width="100" height="56">',
-            $imageExtension->getImage($image, '100x-inset')
-        );
-    }
-
-    public function testGuessRatioOnlyHeightWithInset(): void
-    {
-        $imageExtension = new ImageExtension(null, [], [], true);
-
-        $image = $this->image;
-        $image['thumbnails']['x100-inset'] = '/uploads/media/x100-inset/01/image.jpg?v=1-0';
-        $image['thumbnails']['x100-inset.webp'] = '/uploads/media/x100-inset/01/image.webp?v=1-0';
-
-        $this->assertSame(
-            '<img alt="Title" title="Description" src="/uploads/media/x100-inset/01/image.jpg?v=1-0" width="178" height="100">',
-            $imageExtension->getImage($image, 'x100-inset')
-        );
-    }
-
-    public function testGuessRatioWidthAndHeightWithInset(): void
-    {
-        $imageExtension = new ImageExtension(null, [], [], true);
-
-        $image = $this->image;
-        $image['thumbnails']['100x100-inset'] = '/uploads/media/100x100-inset/01/image.jpg?v=1-0';
-        $image['thumbnails']['100x100-inset.webp'] = '/uploads/media/100x100-inset/01/image.webp?v=1-0';
-
-        $this->assertSame(
-            '<img alt="Title" title="Description" src="/uploads/media/100x100-inset/01/image.jpg?v=1-0" width="100" height="56">',
-            $imageExtension->getImage($image, '100x100-inset')
-        );
-    }
-
-    public function testGuessRatioWidthAndHeightWithInsetQuader(): void
-    {
-        $imageExtension = new ImageExtension(null, [], [], true);
-
-        $image = $this->image;
-        $image['thumbnails']['200x50-inset'] = '/uploads/media/200x50-inset/01/image.jpg?v=1-0';
-        $image['thumbnails']['200x50-inset.webp'] = '/uploads/media/200x50-inset/01/image.webp?v=1-0';
-
-        $this->assertSame(
-            '<img alt="Title" title="Description" src="/uploads/media/200x50-inset/01/image.jpg?v=1-0" width="89" height="50">',
-            $imageExtension->getImage($image, '200x50-inset')
-        );
-    }
-
-    public function testGuessRatioOnlyWidthWithPrefix(): void
-    {
-        $imageExtension = new ImageExtension(null, [], [], true);
-
-        $image = $this->image;
-        $image['thumbnails']['sulu-100x'] = '/uploads/media/sulu-100x/01/image.jpg?v=1-0';
-        $image['thumbnails']['sulu-100x.webp'] = '/uploads/media/sulu-100x/01/image.webp?v=1-0';
-
-        $this->assertSame(
-            '<img alt="Title" title="Description" src="/uploads/media/sulu-100x/01/image.jpg?v=1-0" width="100" height="56">',
-            $imageExtension->getImage($image, 'sulu-100x')
-        );
-    }
-
-    public function testGuessRatioOnlyWidthWithPrefixAt2AndInset(): void
-    {
-        $imageExtension = new ImageExtension(null, [], [], true);
-
-        $image = $this->image;
-        $image['thumbnails']['sulu-100x@2x-inset'] = '/uploads/media/sulu-100x@2x-inset/01/image.jpg?v=1-0';
-        $image['thumbnails']['sulu-100x@2x-inset.webp'] = '/uploads/media/sulu-100x@2x-inset/01/image.webp?v=1-0';
-
-        $this->assertSame(
-            '<img alt="Title" title="Description" src="/uploads/media/sulu-100x@2x-inset/01/image.jpg?v=1-0" width="100" height="56">',
-            $imageExtension->getImage($image, 'sulu-100x@2x-inset')
-        );
+        yield ['100x', '100', '56'];
+        yield ['x100', '178', '100'];
+        yield ['100x100', '100', '100'];
+        yield ['200x50', '200', '50'];
+        yield ['100x@2x', '200', '113'];
+        yield ['x100@2x', '356', '200'];
+        yield ['100x100@2x', '200', '200'];
+        yield ['200x50@2x', '400', '100'];
+        yield ['100x-inset', '100', '56'];
+        yield ['x100-inset', '178', '100'];
+        yield ['100x100-inset', '100', '56'];
+        yield ['200x50-inset', '89', '50'];
+        yield ['100x-inset@2x', '200', '113'];
+        yield ['x100-inset@2x', '356', '200'];
+        yield ['100x100-inset@2x', '200', '113'];
+        yield ['sulu-100x', '100', '56'];
+        yield ['sulu-x100', '178', '100'];
+        yield ['sulu-100x100', '100', '100'];
+        yield ['sulu-100x-inset', '100', '56'];
+        yield ['sulu-x100-inset', '178', '100'];
+        yield ['sulu-100x100-inset', '100', '56'];
+        yield ['sulu-100x-inset@2x', '200', '113'];
+        yield ['sulu-x100-inset@2x', '356', '200'];
+        yield ['sulu-100x100-inset2x', '200', '113'];
     }
 }

--- a/tests/Unit/ImageExtensionTest.php
+++ b/tests/Unit/ImageExtensionTest.php
@@ -54,6 +54,12 @@ class ImageExtensionTest extends TestCase
                 'sulu-170x170.webp' => '/uploads/media/sulu-170x170/01/image.webp?v=1-0',
                 'sulu-400x400' => '/uploads/media/sulu-400x400/01/image.jpg?v=1-0',
                 'sulu-400x400.webp' => '/uploads/media/sulu-400x400/01/image.webp?v=1-0',
+                'sulu-260x' => '/uploads/media/sulu-400x400/01/image.jpg?v=1-0',
+                'sulu-260x.webp' => '/uploads/media/sulu-400x400/01/image.webp?v=1-0',
+            ],
+            'properties' => [
+                'width' => 1920,
+                'height' => 1080,
             ],
         ];
 
@@ -83,6 +89,10 @@ class ImageExtensionTest extends TestCase
                 'sulu-170x170.webp' => '/uploads/media/sulu-170x170/01/image.webp?v=1-0',
                 'sulu-400x400' => '/uploads/media/sulu-400x400/01/image.svg?v=1-0',
                 'sulu-400x400.webp' => '/uploads/media/sulu-400x400/01/image.webp?v=1-0',
+            ],
+            'properties' => [
+                'width' => 1920,
+                'height' => 1080,
             ],
         ];
     }
@@ -487,6 +497,152 @@ class ImageExtensionTest extends TestCase
                     ],
                 ]
             )
+        );
+    }
+
+    public function testGuessRatioWidthAndHeight(): void
+    {
+        $imageExtension = new ImageExtension(null, [], [], true);
+
+        $image = array_replace_recursive(
+            $this->image,
+            [
+                'thumbnails' => [
+                    '100x100' => '/uploads/media/100x100/01/image.jpg?v=1-0',
+                    '100x100.webp' => '/uploads/media/100x100/01/image.webp?v=1-0',
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            '<img alt="Title" title="Description" src="/uploads/media/100x100/01/image.jpg?v=1-0" width="100" height="100">',
+            $imageExtension->getImage($image, '100x100')
+        );
+    }
+
+    public function testGuessRatioOnlyWidth(): void
+    {
+        $imageExtension = new ImageExtension(null, [], [], true);
+
+        $image = $this->image;
+        $image['thumbnails']['100x'] = '/uploads/media/100x/01/image.jpg?v=1-0';
+        $image['thumbnails']['100x.webp'] = '/uploads/media/100x/01/image.webp?v=1-0';
+
+        $this->assertSame(
+            '<img alt="Title" title="Description" src="/uploads/media/100x/01/image.jpg?v=1-0" width="100" height="56">',
+            $imageExtension->getImage($image, '100x')
+        );
+    }
+
+    public function testGuessRatioOnlyHeight(): void
+    {
+        $imageExtension = new ImageExtension(null, [], [], true);
+
+        $image = $this->image;
+        $image['thumbnails']['x100'] = '/uploads/media/x100/01/image.jpg?v=1-0';
+        $image['thumbnails']['x100.webp'] = '/uploads/media/x100/01/image.webp?v=1-0';
+
+        $this->assertSame(
+            '<img alt="Title" title="Description" src="/uploads/media/x100/01/image.jpg?v=1-0" width="178" height="100">',
+            $imageExtension->getImage($image, 'x100')
+        );
+    }
+
+    public function testGuessRatioOnlyWidthWithAt2(): void
+    {
+        $imageExtension = new ImageExtension(null, [], [], true);
+
+        $image = $this->image;
+        $image['thumbnails']['100x@2x'] = '/uploads/media/100x@2x/01/image.jpg?v=1-0';
+        $image['thumbnails']['100x@2x.webp'] = '/uploads/media/100x@2x/01/image.webp?v=1-0';
+
+        $this->assertSame(
+            '<img alt="Title" title="Description" src="/uploads/media/100x@2x/01/image.jpg?v=1-0" width="100" height="56">',
+            $imageExtension->getImage($image, '100x@2x')
+        );
+    }
+
+    public function testGuessRatioOnlyWidthWithInset(): void
+    {
+        $imageExtension = new ImageExtension(null, [], [], true);
+
+        $image = $this->image;
+        $image['thumbnails']['100x-inset'] = '/uploads/media/100x-inset/01/image.jpg?v=1-0';
+        $image['thumbnails']['100x-inset.webp'] = '/uploads/media/100x-inset/01/image.webp?v=1-0';
+
+        $this->assertSame(
+            '<img alt="Title" title="Description" src="/uploads/media/100x-inset/01/image.jpg?v=1-0" width="100" height="56">',
+            $imageExtension->getImage($image, '100x-inset')
+        );
+    }
+
+    public function testGuessRatioOnlyHeightWithInset(): void
+    {
+        $imageExtension = new ImageExtension(null, [], [], true);
+
+        $image = $this->image;
+        $image['thumbnails']['x100-inset'] = '/uploads/media/x100-inset/01/image.jpg?v=1-0';
+        $image['thumbnails']['x100-inset.webp'] = '/uploads/media/x100-inset/01/image.webp?v=1-0';
+
+        $this->assertSame(
+            '<img alt="Title" title="Description" src="/uploads/media/x100-inset/01/image.jpg?v=1-0" width="178" height="100">',
+            $imageExtension->getImage($image, 'x100-inset')
+        );
+    }
+
+    public function testGuessRatioWidthAndHeightWithInset(): void
+    {
+        $imageExtension = new ImageExtension(null, [], [], true);
+
+        $image = $this->image;
+        $image['thumbnails']['100x100-inset'] = '/uploads/media/100x100-inset/01/image.jpg?v=1-0';
+        $image['thumbnails']['100x100-inset.webp'] = '/uploads/media/100x100-inset/01/image.webp?v=1-0';
+
+        $this->assertSame(
+            '<img alt="Title" title="Description" src="/uploads/media/100x100-inset/01/image.jpg?v=1-0" width="100" height="56">',
+            $imageExtension->getImage($image, '100x100-inset')
+        );
+    }
+
+    public function testGuessRatioWidthAndHeightWithInsetQuader(): void
+    {
+        $imageExtension = new ImageExtension(null, [], [], true);
+
+        $image = $this->image;
+        $image['thumbnails']['200x50-inset'] = '/uploads/media/200x50-inset/01/image.jpg?v=1-0';
+        $image['thumbnails']['200x50-inset.webp'] = '/uploads/media/200x50-inset/01/image.webp?v=1-0';
+
+        $this->assertSame(
+            '<img alt="Title" title="Description" src="/uploads/media/200x50-inset/01/image.jpg?v=1-0" width="89" height="50">',
+            $imageExtension->getImage($image, '200x50-inset')
+        );
+    }
+
+    public function testGuessRatioOnlyWidthWithPrefix(): void
+    {
+        $imageExtension = new ImageExtension(null, [], [], true);
+
+        $image = $this->image;
+        $image['thumbnails']['sulu-100x'] = '/uploads/media/sulu-100x/01/image.jpg?v=1-0';
+        $image['thumbnails']['sulu-100x.webp'] = '/uploads/media/sulu-100x/01/image.webp?v=1-0';
+
+        $this->assertSame(
+            '<img alt="Title" title="Description" src="/uploads/media/sulu-100x/01/image.jpg?v=1-0" width="100" height="56">',
+            $imageExtension->getImage($image, 'sulu-100x')
+        );
+    }
+
+    public function testGuessRatioOnlyWidthWithPrefixAt2AndInset(): void
+    {
+        $imageExtension = new ImageExtension(null, [], [], true);
+
+        $image = $this->image;
+        $image['thumbnails']['sulu-100x@2x-inset'] = '/uploads/media/sulu-100x@2x-inset/01/image.jpg?v=1-0';
+        $image['thumbnails']['sulu-100x@2x-inset.webp'] = '/uploads/media/sulu-100x@2x-inset/01/image.webp?v=1-0';
+
+        $this->assertSame(
+            '<img alt="Title" title="Description" src="/uploads/media/sulu-100x@2x-inset/01/image.jpg?v=1-0" width="100" height="56">',
+            $imageExtension->getImage($image, 'sulu-100x@2x-inset')
         );
     }
 }

--- a/tests/Unit/ImageExtensionTest.php
+++ b/tests/Unit/ImageExtensionTest.php
@@ -501,7 +501,7 @@ class ImageExtensionTest extends TestCase
     }
 
     /**
-     * @dataProvider guessRatioDataProvider
+     * @dataProvider guessAspectRatioDataProvider
      */
     public function testGuessAspectRatio(string $format, string $expectedWidth, string $expectedHeight): void
     {
@@ -514,6 +514,10 @@ class ImageExtensionTest extends TestCase
                     $format => '/uploads/media/' . $format . '/01/image.jpg?v=1-0',
                     $format . '.webp' => '/uploads/media/' . $format . '/01/image.webp?v=1-0',
                 ],
+                'properties' => [
+                    'width' => 1920,
+                    'height' => 1080,
+                ],
             ],
         );
 
@@ -523,7 +527,10 @@ class ImageExtensionTest extends TestCase
         );
     }
 
-    public function guessRatioDataProvider(): \Generator
+    /**
+     * @return \Generator<array{string, string, string}>
+     */
+    public function guessAspectRatioDataProvider(): \Generator
     {
         yield ['100x', '100', '56'];
         yield ['x100', '178', '100'];

--- a/tests/Unit/ImageExtensionTest.php
+++ b/tests/Unit/ImageExtensionTest.php
@@ -19,11 +19,6 @@ use Sulu\Twig\Extensions\ImageExtension;
 class ImageExtensionTest extends TestCase
 {
     /**
-     * @var ImageExtension
-     */
-    private $imageExtension;
-
-    /**
      * @var mixed[]
      */
     private $image;
@@ -40,7 +35,6 @@ class ImageExtensionTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->imageExtension = new ImageExtension('/lazy');
         $this->image = [
             'title' => 'Title',
             'description' => 'Description',
@@ -99,22 +93,28 @@ class ImageExtensionTest extends TestCase
 
     public function testImageTag(): void
     {
+        $imageExtension = new ImageExtension('/lazy');
+
         $this->assertSame(
             '<img alt="Title" title="Description" src="/uploads/media/sulu-100x100/01/image.jpg?v=1-0">',
-            $this->imageExtension->getImage($this->image, 'sulu-100x100')
+            $imageExtension->getImage($this->image, 'sulu-100x100')
         );
     }
 
     public function testImageTagObject(): void
     {
+        $imageExtension = new ImageExtension('/lazy');
+
         $this->assertSame(
             '<img alt="Title" title="Description" src="/uploads/media/sulu-100x100/01/image.jpg?v=1-0">',
-            $this->imageExtension->getImage((object) $this->image, 'sulu-100x100')
+            $imageExtension->getImage((object) $this->image, 'sulu-100x100')
         );
     }
 
     public function testComplexImageTag(): void
     {
+        $imageExtension = new ImageExtension('/lazy');
+
         $this->assertSame(
             '<img alt="Logo"' .
             ' title="Description"' .
@@ -123,7 +123,7 @@ class ImageExtensionTest extends TestCase
             ' sizes="(max-width: 1024px) 100vw, (max-width: 800px) 100vw, 100vw"' .
             ' id="image-id"' .
             ' class="image-class">',
-            $this->imageExtension->getImage(
+            $imageExtension->getImage(
                 $this->image,
                 [
                     'src' => 'sulu-400x400',
@@ -139,6 +139,8 @@ class ImageExtensionTest extends TestCase
 
     public function testPictureTag(): void
     {
+        $imageExtension = new ImageExtension('/lazy');
+
         $this->assertSame(
             '<picture>' .
             '<source media="(max-width: 1024px)"' .
@@ -149,7 +151,7 @@ class ImageExtensionTest extends TestCase
                 ' title="Description"' .
                 ' src="/uploads/media/sulu-400x400/01/image.jpg?v=1-0">' .
             '</picture>',
-            $this->imageExtension->getImage(
+            $imageExtension->getImage(
                 $this->image,
                 'sulu-400x400',
                 [
@@ -162,6 +164,8 @@ class ImageExtensionTest extends TestCase
 
     public function testPictureTagMinimalImage(): void
     {
+        $imageExtension = new ImageExtension('/lazy');
+
         $this->assertSame(
             '<picture>' .
             '<source media="(max-width: 1024px)"' .
@@ -172,7 +176,7 @@ class ImageExtensionTest extends TestCase
             ' title="image"' .
             ' src="/uploads/media/sulu-400x400/01/image.jpg?v=1-0">' .
             '</picture>',
-            $this->imageExtension->getImage(
+            $imageExtension->getImage(
                 $this->minimalImage,
                 'sulu-400x400',
                 [
@@ -185,6 +189,8 @@ class ImageExtensionTest extends TestCase
 
     public function testComplexPictureTag(): void
     {
+        $imageExtension = new ImageExtension('/lazy');
+
         $this->assertSame(
             '<picture>' .
             '<source media="(max-width: 1024px)"' .
@@ -198,7 +204,7 @@ class ImageExtensionTest extends TestCase
                 ' src="/uploads/media/sulu-400x400/01/image.jpg?v=1-0"' .
                 ' class="image-class">' .
             '</picture>',
-            $this->imageExtension->getImage(
+            $imageExtension->getImage(
                 $this->image,
                 [
                     'src' => 'sulu-400x400',
@@ -220,14 +226,18 @@ class ImageExtensionTest extends TestCase
 
     public function testLazyImageTag(): void
     {
+        $imageExtension = new ImageExtension('/lazy');
+
         $this->assertSame(
             '<img alt="Title" title="Description" src="/lazy/sulu-100x100.svg" data-src="/uploads/media/sulu-100x100/01/image.jpg?v=1-0" class="lazyload">',
-            $this->imageExtension->getLazyImage($this->image, 'sulu-100x100')
+            $imageExtension->getLazyImage($this->image, 'sulu-100x100')
         );
     }
 
     public function testLazyComplexImageTag(): void
     {
+        $imageExtension = new ImageExtension('/lazy');
+
         $this->assertSame(
             '<img alt="Logo"' .
             ' title="Description"' .
@@ -238,7 +248,7 @@ class ImageExtensionTest extends TestCase
             ' sizes="(max-width: 1024px) 100vw, (max-width: 800px) 100vw, 100vw"' .
             ' id="image-id"' .
             ' class="image-class lazyload">',
-            $this->imageExtension->getLazyImage(
+            $imageExtension->getLazyImage(
                 $this->image,
                 [
                     'src' => 'sulu-400x400',
@@ -254,6 +264,8 @@ class ImageExtensionTest extends TestCase
 
     public function testLazyComplexImageTagMinimalImage(): void
     {
+        $imageExtension = new ImageExtension('/lazy');
+
         $this->assertSame(
             '<img alt="image"' .
             ' title="image"' .
@@ -264,7 +276,7 @@ class ImageExtensionTest extends TestCase
             ' sizes="(max-width: 1024px) 100vw, (max-width: 800px) 100vw, 100vw"' .
             ' id="image-id"' .
             ' class="image-class lazyload">',
-            $this->imageExtension->getLazyImage(
+            $imageExtension->getLazyImage(
                 $this->minimalImage,
                 [
                     'src' => 'sulu-400x400',
@@ -279,6 +291,8 @@ class ImageExtensionTest extends TestCase
 
     public function testLazyPictureTag(): void
     {
+        $imageExtension = new ImageExtension('/lazy');
+
         $this->assertSame(
             '<picture>' .
             '<source media="(max-width: 1024px)"' .
@@ -293,7 +307,7 @@ class ImageExtensionTest extends TestCase
             ' data-src="/uploads/media/sulu-400x400/01/image.jpg?v=1-0"' .
             ' class="lazyload">' .
             '</picture>',
-            $this->imageExtension->getLazyImage(
+            $imageExtension->getLazyImage(
                 $this->image,
                 'sulu-400x400',
                 [
@@ -306,6 +320,8 @@ class ImageExtensionTest extends TestCase
 
     public function testLazyComplexPictureTag(): void
     {
+        $imageExtension = new ImageExtension('/lazy');
+
         $this->assertSame(
             '<picture>' .
             '<source media="(max-width: 1024px)"' .
@@ -322,7 +338,7 @@ class ImageExtensionTest extends TestCase
             ' data-src="/uploads/media/sulu-400x400/01/image.jpg?v=1-0"' .
             ' class="image-class lazyload">' .
             '</picture>',
-            $this->imageExtension->getLazyImage(
+            $imageExtension->getLazyImage(
                 $this->image,
                 [
                     'src' => 'sulu-400x400',
@@ -344,14 +360,16 @@ class ImageExtensionTest extends TestCase
 
     public function testHasLazyImage(): void
     {
-        $this->assertFalse($this->imageExtension->hasLazyImage());
-        $this->imageExtension->getImage($this->image, 'sulu-400x400');
-        $this->assertFalse($this->imageExtension->hasLazyImage());
-        $this->imageExtension->getLazyImage($this->image, 'sulu-400x400');
-        $this->assertTrue($this->imageExtension->hasLazyImage());
-        $this->imageExtension->getLazyImage($this->image, 'sulu-400x400');
-        $this->imageExtension->getImage($this->image, 'sulu-400x400');
-        $this->assertTrue($this->imageExtension->hasLazyImage());
+        $imageExtension = new ImageExtension('/lazy');
+
+        $this->assertFalse($imageExtension->hasLazyImage());
+        $imageExtension->getImage($this->image, 'sulu-400x400');
+        $this->assertFalse($imageExtension->hasLazyImage());
+        $imageExtension->getLazyImage($this->image, 'sulu-400x400');
+        $this->assertTrue($imageExtension->hasLazyImage());
+        $imageExtension->getLazyImage($this->image, 'sulu-400x400');
+        $imageExtension->getImage($this->image, 'sulu-400x400');
+        $this->assertTrue($imageExtension->hasLazyImage());
     }
 
     public function testDefaultAttributes(): void
@@ -501,9 +519,9 @@ class ImageExtensionTest extends TestCase
     }
 
     /**
-     * @dataProvider guessAspectRatioDataProvider
+     * @dataProvider aspectRatioDataProvider
      */
-    public function testGuessAspectRatio(string $format, string $expectedWidth, string $expectedHeight): void
+    public function testAspectRatio(string $format, string $expectedWidth, string $expectedHeight): void
     {
         $imageExtension = new ImageExtension(null, [], [], true);
 
@@ -528,9 +546,52 @@ class ImageExtensionTest extends TestCase
     }
 
     /**
+     * @dataProvider aspectRatioDataProvider
+     */
+    public function testAspectRatioWithConfiguration(string $format, string $expectedWidth, string $expectedHeight): void
+    {
+        preg_match('/(\d+)?x(\d+)?(-inset)?(@)?(\d)?(x)?/', $format, $matches);
+
+        $scale = !empty($matches[5]) ? (float) $matches[5] : 1;
+        $x = !empty($matches[1]) ? (int) $matches[1] : null;
+        $y = !empty($matches[2]) ? (int) $matches[2] : null;
+        $isInset = !empty($matches[3]);
+
+        $imageExtension = new ImageExtension(null, [], [], true, [
+            $format => [
+                'scale' => [
+                    'x' => $x,
+                    'y' => $y,
+                    'mode' => $isInset ? 1 : 2,
+                    'retina' => 1 !== $scale,
+                ],
+            ],
+        ]);
+
+        $image = array_replace_recursive(
+            $this->image,
+            [
+                'thumbnails' => [
+                    $format => '/uploads/media/' . $format . '/01/image.jpg?v=1-0',
+                    $format . '.webp' => '/uploads/media/' . $format . '/01/image.webp?v=1-0',
+                ],
+                'properties' => [
+                    'width' => 1920,
+                    'height' => 1080,
+                ],
+            ],
+        );
+
+        $this->assertSame(
+            '<img alt="Title" title="Description" src="/uploads/media/' . $format . '/01/image.jpg?v=1-0" width="' . $expectedWidth . '" height="' . $expectedHeight . '">',
+            $imageExtension->getImage($image, $format)
+        );
+    }
+
+    /**
      * @return \Generator<array{string, string, string}>
      */
-    public function guessAspectRatioDataProvider(): \Generator
+    public function aspectRatioDataProvider(): \Generator
     {
         yield ['100x', '100', '56'];
         yield ['x100', '178', '100'];


### PR DESCRIPTION
**Set width and height attribute automatically**

Since Sulu 2.3 the original image width and height are save as properties.
This allows us the guess the width and height dimension of a given image format.

With setting the width and height attribute modern browsers avoid a layer shifts
and the page will not jump when images are loaded.

This feature can be activated the following way:

```yaml
services:
    Sulu\Twig\Extensions\ImageExtension:
        arguments:
             $aspectRatio: true
             $imageFormatConfiguration: '%sulu_media.image.formats%'
```

So if we have an original image of 1920x1080 and have a image format called 100x:

```twig
{{ get_image(headerImage, '100x') }}
```

Will add automatically the width and height attributes to the imgage tag:

```twig
<img alt="Title" title="Description" src="/uploads/media/100x/01/image.jpg?v=1-0" width="100" height="56">
```

This only works when writing image formats in specific format 100x, x100, 100x100, 100x100-inset, 100x@2x, ...
for all other cases this option not be activated.

fixes #36 