### PR TITLE
Fix svg icon font with class prefix and suffix

### DIFF
--- a/src/IconExtension.php
+++ b/src/IconExtension.php
@@ -122,7 +122,7 @@ class IconExtension extends AbstractExtension
             '<svg%s><use xlink:href="%s#%s"></use></svg>',
             $this->renderAttributes($attributes),
             $iconSet['path'],
-            $iconSet['classPrefix'] . $icon
+            $iconSet['classPrefix'] . $icon . $iconSet['classSuffix']
         );
     }
 

--- a/src/IconExtension.php
+++ b/src/IconExtension.php
@@ -122,7 +122,7 @@ class IconExtension extends AbstractExtension
             '<svg%s><use xlink:href="%s#%s"></use></svg>',
             $this->renderAttributes($attributes),
             $iconSet['path'],
-            $icon
+            $iconSet['classPrefix'] . $icon
         );
     }
 

--- a/tests/Unit/IconExtensionTest.php
+++ b/tests/Unit/IconExtensionTest.php
@@ -112,7 +112,7 @@ class IconExtensionTest extends TestCase
         ]);
 
         $this->assertSame(
-            '<svg class="icon icon-test"><use xlink:href="/path/to/symbol-defs.svg#test"></use></svg>',
+            '<svg class="icon icon-test"><use xlink:href="/path/to/symbol-defs.svg#icon-test"></use></svg>',
             $iconExtension->getIcon('test')
         );
     }
@@ -127,7 +127,7 @@ class IconExtensionTest extends TestCase
         ]);
 
         $this->assertSame(
-            '<svg role="none" class="icon icon-test"><use xlink:href="/path/to/symbol-defs.svg#test"></use></svg>',
+            '<svg role="none" class="icon icon-test"><use xlink:href="/path/to/symbol-defs.svg#icon-test"></use></svg>',
             $iconExtension->getIcon('test', ['role' => 'none'])
         );
     }
@@ -147,7 +147,7 @@ class IconExtensionTest extends TestCase
         );
 
         $this->assertSame(
-            '<svg role="none" class="icon icon-test"><use xlink:href="/path/to/symbol-defs.svg#test"></use></svg>',
+            '<svg role="none" class="icon icon-test"><use xlink:href="/path/to/symbol-defs.svg#icon-test"></use></svg>',
             $iconExtension->getIcon('test')
         );
     }
@@ -167,7 +167,7 @@ class IconExtensionTest extends TestCase
         );
 
         $this->assertSame(
-            '<svg class="icon icon-test"><use xlink:href="/path/to/symbol-defs.svg#test"></use></svg>',
+            '<svg class="icon icon-test"><use xlink:href="/path/to/symbol-defs.svg#icon-test"></use></svg>',
             $iconExtension->getIcon('test', ['role' => null])
         );
     }
@@ -185,7 +185,7 @@ class IconExtensionTest extends TestCase
         ]);
 
         $this->assertSame(
-            '<svg class="add-class my-icon my-icon-test-new"><use xlink:href="/path/to/symbol-defs.svg#test"></use></svg>',
+            '<svg class="add-class my-icon my-icon-test-new"><use xlink:href="/path/to/symbol-defs.svg#icon-test"></use></svg>',
             $iconExtension->getIcon('test', 'add-class', 'other')
         );
     }
@@ -200,7 +200,7 @@ class IconExtensionTest extends TestCase
         ]);
 
         $this->assertSame(
-            '<svg class="icon icon-test"><use xlink:href="/path/to/symbol-defs.svg#test"></use></svg>',
+            '<svg class="icon icon-test"><use xlink:href="/path/to/symbol-defs.svg#icon-test"></use></svg>',
             $iconExtension->getIcon('test', null, 'other')
         );
     }

--- a/tests/Unit/IconExtensionTest.php
+++ b/tests/Unit/IconExtensionTest.php
@@ -185,7 +185,7 @@ class IconExtensionTest extends TestCase
         ]);
 
         $this->assertSame(
-            '<svg class="add-class my-icon my-icon-test-new"><use xlink:href="/path/to/symbol-defs.svg#icon-test"></use></svg>',
+            '<svg class="add-class my-icon my-icon-test-new"><use xlink:href="/path/to/symbol-defs.svg#my-icon-test-new"></use></svg>',
             $iconExtension->getIcon('test', 'add-class', 'other')
         );
     }


### PR DESCRIPTION
Icomoon does in the export set the classprefix also to the icon symbols.defs id="" selectors. So it also need to be there.

Example:

```yaml
    Sulu\Twig\Extensions\IconExtension:
        arguments:
            $iconSets:
                default:
                    type: 'svg'
                    path: '/static/icomoon-sulu/symbol-defs.svg'
                    className: 'u-icon'
                    classPrefix: 'u-icon-'
```