### PR TITLE
Replace loading auto with img loading attribute

### DIFF
--- a/src/ImageExtension.php
+++ b/src/ImageExtension.php
@@ -378,6 +378,8 @@ class ImageExtension extends AbstractExtension
 
                 // Replace thumbnail format in srcset.
                 $value = $this->srcsetThumbnailReplace($value, $thumbnails);
+            } elseif ('loading' === $key && 'auto' === $value) {
+                continue;
             }
 
             $output .= sprintf(' %s="%s"', $key, htmlentities($value));

--- a/tests/Unit/ImageExtensionTest.php
+++ b/tests/Unit/ImageExtensionTest.php
@@ -382,6 +382,38 @@ class ImageExtensionTest extends TestCase
         );
     }
 
+    public function testRemoveDefaultAttributes(): void
+    {
+        $imageExtension = new ImageExtension(null, ['loading' => 'lazy']);
+
+        $this->assertSame(
+            '<img alt="Title" title="Description" src="/uploads/media/sulu-100x100/01/image.jpg?v=1-0">',
+            $imageExtension->getImage(
+                $this->image,
+                [
+                    'src' => 'sulu-100x100',
+                    'loading' => null,
+                ]
+            )
+        );
+    }
+
+    public function testReplaceLoadingAuto(): void
+    {
+        $imageExtension = new ImageExtension(null, ['loading' => 'lazy']);
+
+        $this->assertSame(
+            '<img alt="Title" title="Description" src="/uploads/media/sulu-100x100/01/image.jpg?v=1-0">',
+            $imageExtension->getImage(
+                $this->image,
+                [
+                    'src' => 'sulu-100x100',
+                    'loading' => 'auto',
+                ]
+            )
+        );
+    }
+
     public function testDefaultAttributesUnset(): void
     {
         $imageExtension = new ImageExtension(null, ['loading' => 'lazy']);


### PR DESCRIPTION
The `<img loading="auto">` attribute is not part of the http specification:

https://html.spec.whatwg.org/multipage/urls-and-fetching.html#lazy-loading-attributes

There only exist `eager` and `lazy`. So it should be avoided to be used. It is also mention by google web dev documentation to avoid it aslong as it is not part of the specification https://html.spec.whatwg.org/multipage/urls-and-fetching.html#lazy-loading-attributes.