### PR TITLE
Fix image extension with none exist properties

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,10 @@
         "symfony/property-access": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
         "thecodingmachine/phpstan-strict-rules": "^0.12"
     },
+    "conflict": {
+        "symfony/intl": ">=7.0",
+        "symfony/property-access": ">=7.0"
+    },
     "suggest": {
         "symfony/property-access": "The ImageExtension requires the symfony/property-access service.",
         "symfony/intl": "The IntlExtension requires the symfony/intl service."

--- a/src/ImageExtension.php
+++ b/src/ImageExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Twig\Extensions;
 
+use Symfony\Component\PropertyAccess\Exception\AccessException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Twig\Extension\AbstractExtension;
@@ -490,7 +491,12 @@ class ImageExtension extends AbstractExtension
             return [$width, $height];
         }
 
-        $properties = $this->getPropertyAccessor()->getValue($media, 'properties');
+        try {
+            $properties = $this->getPropertyAccessor()->getValue($media, 'properties');
+        } catch (AccessException $e) {
+            $properties = [];
+        }
+
         $originalWidth = $properties['width'] ?? null;
         $originalHeight = $properties['height'] ?? null;
 

--- a/tests/Unit/ImageExtensionTest.php
+++ b/tests/Unit/ImageExtensionTest.php
@@ -635,6 +635,28 @@ class ImageExtensionTest extends TestCase
         );
     }
 
+    public function testAspectRatioNoProperties(): void
+    {
+        $imageExtension = new ImageExtension(null, [], [], true);
+
+        $image = array_replace_recursive(
+            $this->image,
+            [
+                'thumbnails' => [
+                    '200x100-inset' => '/uploads/media/200x100-inset/01/image.jpg?v=1-0',
+                    '200x100-inset' . '.webp' => '/uploads/media/200x100-inset/01/image.webp?v=1-0',
+                ],
+            ]
+        );
+
+        unset($image['properties']);
+
+        $this->assertSame(
+            '<img alt="Title" title="Description" src="/uploads/media/200x100-inset/01/image.jpg?v=1-0">',
+            $imageExtension->getImage($image, '200x100-inset')
+        );
+    }
+
     /**
      * @dataProvider aspectRatioDataProvider
      */


### PR DESCRIPTION
Currently it fails if the given object does not have the `properties` variable or key in it.