### PR TITLE
Fix sources in webp source tags of image extension

### DIFF
--- a/src/ImageExtension.php
+++ b/src/ImageExtension.php
@@ -260,6 +260,7 @@ class ImageExtension extends AbstractExtension
                 if ($srcset) {
                     $sources[] = [
                         'srcset' => $srcset,
+                        'sizes' => $attributes['sizes'] ?? null,
                         'type' => $type,
                     ];
                 }

--- a/tests/Unit/ImageExtensionTest.php
+++ b/tests/Unit/ImageExtensionTest.php
@@ -169,6 +169,7 @@ class ImageExtensionTest extends TestCase
         $this->assertSame(
             '<picture>' .
             '<source srcset="/uploads/media/sulu-100x100/01/image.webp?v=1-0 460w, /uploads/media/sulu-170x170/01/image.webp?v=1-0 800w, /uploads/media/sulu-400x400/01/image.webp?v=1-0 1024w"' .
+            ' sizes="(max-width: 1024px) 100vw, (max-width: 800px) 100vw, 100vw"' .
             ' type="image/webp">' .
             '<img alt="Logo"' .
             ' title="Description"' .


### PR DESCRIPTION
Add sizes attributes to source tags in the testComplexWebpPictureTag() function